### PR TITLE
build(arm): added support for arm32v7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2.1
+
+orbs:
+  docker-buildx: foodles/docker-buildx@0.0.1
+
+workflows:
+  version: 2
+  build-and-publish-docker-image:
+    jobs:
+      - docker-buildx/publish:
+          name: build_deploy_docker_dev
+          context: docker-publishing
+          checkout: true
+          attach-workspace: true
+          image: foodlestech/logzio-docker-collector-metrics
+          tag: develop
+          filters:
+            branches:
+              only:
+                - master

--- a/dockerfile
+++ b/dockerfile
@@ -1,16 +1,23 @@
-FROM python:3.7-slim
+FROM arm32v7/python:3.7-slim
 
 COPY requirements.txt ./requirements.txt
 
+ENV PACKAGE=metricbeat-7.5.2-linux-arm32v7.tar.gz
+ENV METRICBEAT_DIR=/opt/metricbeat
+ENV METRICBEAT_CONFIG_DIR=/etc/metricbeat
 ENV LOGZIO_DIR_PATH /logzio
 ENV LOGZIO_MODULES_PATH ${LOGZIO_DIR_PATH}/modules
 
+COPY $PACKAGE $PACKAGE
+COPY metricbeat.sh /usr/bin/metricbeat
 
 RUN apt-get update && \
     apt-get install -y curl wget && \
-    curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.5.2-amd64.deb && \
-    dpkg -i metricbeat-7.5.2-amd64.deb && \
-    rm metricbeat-7.5.2-amd64.deb && \
+    mkdir -p $METRICBEAT_DIR && \
+    mkdir -p $METRICBEAT_CONFIG_DIR && \
+    tar --no-same-owner --strip-components=1 -zxf "$PACKAGE" -C $METRICBEAT_DIR && \
+    mv $METRICBEAT_DIR/metricbeat.yml $METRICBEAT_CONFIG_DIR && \
+    rm -f "$PACKAGE" && \
     wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt && \
     mkdir -p /etc/pki/tls/certs && \
     cp TrustExternalCARoot_and_USERTrustRSAAAACA.crt /etc/pki/tls/certs/ && \

--- a/metricbeat.sh
+++ b/metricbeat.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Script to run Metricbeat in foreground with the same path settings that
+# the init script / systemd unit file would do.
+
+exec /opt/metricbeat/metricbeat \
+  -path.home /opt/metricbeat \
+  -path.config /etc/metricbeat \
+  -path.data /opt/metricbeat \
+  -path.logs /opt/metricbeat \
+  "$@"


### PR DESCRIPTION
The binary used in the python script is in system path.
So I add a shell script in `/usr/bin` to call the binary installed with the `tar.gz`.
The config path is hard coded in the script pointing to `/etc/metricbeat/metricbeat.yml`, so I move that file to the path.